### PR TITLE
Update plutocracy.py

### DIFF
--- a/metrics/plutocracy.py
+++ b/metrics/plutocracy.py
@@ -88,7 +88,8 @@ def calc_swifty_cancellation_number_additive(all_weighted_voters: Dict[str, Dict
     weight_to_cancel = {voter: all_weighted_voters.get(voter).get("weight") 
                                  for voter in voters_to_cancel}
     minimum_weight_possible = min(nft_weight_dict.values())
-    swifty_cancellation_number = weight_to_cancel/minimum_weight_possible
+    total_weight_to_cancel = sum(weight_to_cancel.values())
+    swifty_cancellation_number = total_weight_to_cancel / minimum_weight_possible
 
     if verbose:
         print(f"The swifty cancellation number is {swifty_cancellation_number}")


### PR DESCRIPTION
Seems there's one step missing, atm dividing the dictionary by a float. I guess the intent was to calculate the sum of the weights in weight_to_cancel and then divide that sum by the minimum_weight_possible.