### PR TITLE
Added an initial policies doc with pull requests.

### DIFF
--- a/policies.md
+++ b/policies.md
@@ -1,0 +1,21 @@
+This document lays out the policies for this repo. 
+
+**TODO:** It may eventually be merged into the main `README`. 
+
+## Pull Requests
+
+It is always nice to have collaborators contributing new code to an open-source repository. To ensure that these contributions maintain the functionality and standards of the existing repository, there are certain policies that must be followed for the 
+
+1. The pull request should address an existing Issue, either to add a new feature or fix a bug in an existing feature. 
+2. The code in the pull request should be well-written, with docstrings and comments, adhering to the standard format established in the rpeository. 
+3. The code should make any existing unit tests fail. (This is enforced through a GitHub Action that automatically runs all tests.) 
+4. If implementing a new feature, the code must add unit tests to demonstrate and verify the most important functionalities of the feature. 
+5. The pull request must be reviewed and approved by a member of the core team.
+
+As of September 16, 2024, the core team consists of:
+* [Angela Kreitenweis](https://github.com/AngelaKTE)
+* [Vitor Marthendal Nunes](https://github.com/marthendalnunes)
+* Octopus, researcher at [Eight Arms Nine Brains](https://github.com/eightarmsninebrains)
+
+Please tag at least one of these accounts to review your pull request. 
+


### PR DESCRIPTION
In `policies.md`, we now have a doc that specifies a set of conditions under which a pull request would be accepted. 

This closes Issue #30 , 

If needed in the future, more explicit policies can be added and/or this document can be merged into the `README` file. This should suffice for an initial proof-of-concept. 